### PR TITLE
CORS修正: 同一オリジンAPIに変更

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -272,7 +272,7 @@
   </footer>
 
   <script>
-    const API = location.hostname === 'localhost' ? 'http://localhost:3000' : 'https://api.chatweb.ai';
+    const API = location.hostname === 'localhost' ? 'http://localhost:3000' : '';
     const msgs = document.getElementById('messages');
     const input = document.getElementById('input');
 


### PR DESCRIPTION
## 概要
フロントエンド(`chatweb.ai`)からのAPI呼び出しで CORS エラーが発生していた問題を修正。

## 原因
`chatweb.ai` → `api.chatweb.ai` はクロスオリジン。両方同じ Lambda なのに CORS ヘッダーがなかった。

## 修正
API ベース URL を相対パス（同一オリジン）に変更。`/api/v1/chat` で呼ぶのでCORS不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)