### PR TITLE
feat: multi-platform deploy + gateway AI fix

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,4 @@
-app = "nanobot"
+app = "nanobot-ai"
 primary_region = "nrt"
 
 [build]

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,7 +276,7 @@ async fn cmd_gateway(port: u16, verbose: bool, http: bool, http_port: u16) -> Re
         // Already handled by env filter
     }
 
-    let cfg = config::load_config(None);
+    let cfg = config::load_config_from_env();
 
     #[cfg(feature = "http-api")]
     if http {
@@ -284,10 +284,10 @@ async fn cmd_gateway(port: u16, verbose: bool, http: bool, http_port: u16) -> Re
         use nanobot_core::session::file_store::FileSessionStore;
 
         let workspace = cfg.workspace_path();
-        let state = std::sync::Arc::new(AppState {
-            config: cfg.clone(),
-            sessions: tokio::sync::Mutex::new(Box::new(FileSessionStore::new(&workspace))),
-        });
+        let state = std::sync::Arc::new(AppState::with_provider(
+            cfg.clone(),
+            Box::new(FileSessionStore::new(&workspace)),
+        ));
 
         let addr = format!("0.0.0.0:{}", http_port);
         println!(


### PR DESCRIPTION
## Summary
- **Gateway AI修正**: `AppState::with_provider()` を使うようにして、Fly.ioでもAI返信が動作
- **環境変数対応**: `load_config_from_env()` でOpenAI/Anthropicキーを環境変数から読む
- **Fly.ioデプロイ**: `nanobot-ai.fly.dev` にデプロイ完了・動作確認済み
- **SAMテンプレート**: OpenAI APIキーパラメータ追加

## デプロイ先
| Platform | URL | Status |
|----------|-----|--------|
| AWS Lambda | https://chatweb.ai | ✅ 稼働中 |
| Fly.io | https://nanobot-ai.fly.dev | ✅ 稼働中 |

## Test plan
- [x] `cargo test -p nanobot-core` 全通過
- [x] `cargo build --features http-api` 成功
- [x] Fly.io ヘルスチェック OK
- [x] Fly.io チャットAPI AI返信確認
- [x] AWS Lambda チャットAPI AI返信確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)