### PR TITLE
feat: chatweb.ai branding + recipe cards + bot setup

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>nanobot - AIチャット</title>
+  <title>chatweb.ai - AIチャット</title>
   <meta name="description" content="AIとすぐに話せる。LINE・Telegramでも使える。無料。">
   <style>
     :root {
@@ -26,7 +26,7 @@
       min-height: 100vh;
     }
 
-    /* Nav - minimal */
+    /* Nav */
     nav {
       padding: 16px 24px;
       display: flex;
@@ -48,17 +48,17 @@
     }
     .lang-sw button.on { background: var(--accent); color: #fff; }
 
-    /* Main layout */
+    /* Main */
     .main {
       max-width: 800px;
       margin: 0 auto;
       padding: 40px 24px 80px;
     }
 
-    /* Hero - super simple */
+    /* Hero */
     .hero {
       text-align: center;
-      margin-bottom: 40px;
+      margin-bottom: 32px;
     }
     .hero h1 {
       font-size: 32px;
@@ -77,7 +77,7 @@
       border: 1px solid var(--border);
       border-radius: 16px;
       overflow: hidden;
-      margin-bottom: 32px;
+      margin-bottom: 24px;
     }
     .chat-messages {
       height: 320px;
@@ -94,6 +94,7 @@
       font-size: 14px;
       line-height: 1.5;
       word-break: break-word;
+      white-space: pre-wrap;
     }
     .msg.bot {
       background: #1a1a2e;
@@ -112,36 +113,51 @@
       border-bottom-left-radius: 4px;
       color: var(--muted);
     }
-    .msg.typing::after {
-      content: '';
-      animation: dots 1.5s infinite;
-    }
     @keyframes dots {
       0%, 20% { content: '.'; }
       40% { content: '..'; }
       60%, 100% { content: '...'; }
     }
-    /* Suggest buttons */
-    .suggests {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
-      padding: 12px 20px 0;
+
+    /* Recipe cards */
+    .recipes {
+      margin-bottom: 32px;
     }
-    .suggest-btn {
-      background: rgba(99,102,241,0.1);
-      border: 1px solid rgba(99,102,241,0.2);
-      color: var(--accent);
-      padding: 6px 14px;
-      border-radius: 20px;
-      font-size: 13px;
+    .recipes h2 {
+      font-size: 16px;
+      font-weight: 700;
+      margin-bottom: 12px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .recipe-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+      margin-bottom: 20px;
+    }
+    .recipe-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 14px;
       cursor: pointer;
       transition: all 0.15s;
-      white-space: nowrap;
     }
-    .suggest-btn:hover {
-      background: rgba(99,102,241,0.2);
+    .recipe-card:hover {
       border-color: var(--accent);
+      transform: translateY(-1px);
+    }
+    .recipe-card h4 {
+      font-size: 13px;
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
+    .recipe-card p {
+      font-size: 11px;
+      color: var(--muted);
+      line-height: 1.4;
     }
 
     .chat-input {
@@ -168,14 +184,13 @@
       cursor: pointer;
     }
     .chat-input button:hover { color: var(--accent-hover); }
-    .chat-input button:disabled { color: var(--muted); cursor: default; }
 
     /* Channel buttons */
     .channels {
       display: grid;
       grid-template-columns: 1fr 1fr;
       gap: 12px;
-      margin-bottom: 40px;
+      margin-bottom: 32px;
     }
     .ch-btn {
       display: flex;
@@ -195,24 +210,6 @@
     .ch-btn.tg { background: var(--tg); }
     .ch-btn svg { flex-shrink: 0; }
 
-    /* Info cards */
-    .info {
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: 12px;
-      margin-bottom: 40px;
-    }
-    .info-card {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 20px;
-      text-align: center;
-    }
-    .info-card .ic { font-size: 24px; margin-bottom: 8px; }
-    .info-card h3 { font-size: 13px; margin-bottom: 4px; }
-    .info-card p { font-size: 12px; color: var(--muted); }
-
     /* Footer */
     footer {
       text-align: center;
@@ -225,14 +222,14 @@
     @media (max-width: 600px) {
       .hero h1 { font-size: 24px; }
       .channels { grid-template-columns: 1fr; }
-      .info { grid-template-columns: 1fr; }
+      .recipe-grid { grid-template-columns: 1fr; }
       .chat-messages { height: 260px; }
     }
   </style>
 </head>
 <body>
   <nav>
-    <div class="logo"><span>nano</span>bot</div>
+    <div class="logo"><span>chat</span>web.ai</div>
     <div class="lang-sw">
       <button onclick="setLang('ja')" id="l-ja">JA</button>
       <button onclick="setLang('en')" id="l-en">EN</button>
@@ -241,58 +238,41 @@
 
   <div class="main">
     <div class="hero">
-      <h1 id="t-title">AIと話してみよう</h1>
-      <p id="t-sub">下のチャットですぐに試せます。無料。</p>
+      <h1 id="t-title">AIに何でも頼んでみよう</h1>
+      <p id="t-sub">24時間稼働のAIアシスタント。リサーチ・自動化・開発まで。</p>
     </div>
 
     <!-- Live chat -->
     <div class="chat-box">
       <div class="chat-messages" id="messages">
-        <div class="msg bot" id="t-welcome">こんにちは！何でも聞いてください。</div>
-        <div class="suggests" id="suggests"></div>
+        <div class="msg bot" id="t-welcome">こんにちは！何でもお任せください。下のカードから選ぶか、自由に入力してください。</div>
       </div>
       <div class="chat-input">
-        <input type="text" id="input" placeholder="メッセージを入力..." data-ph-ja="メッセージを入力..." data-ph-en="Type a message..." autocomplete="off">
-        <button onclick="send()" id="send-btn" data-ja="送信" data-en="Send">送信</button>
+        <input type="text" id="input" placeholder="何でも聞いてください..." autocomplete="off">
+        <button onclick="send()" id="send-btn">送信</button>
       </div>
     </div>
+
+    <!-- Recipe cards -->
+    <div id="recipe-section"></div>
 
     <!-- Channel buttons -->
     <div class="channels">
-      <a href="https://line.me/R/ti/p/" class="ch-btn line" target="_blank">
+      <a href="https://line.me/R/ti/p/@619jcqqh" class="ch-btn line" target="_blank">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none"><path d="M12 2C6.48 2 2 5.81 2 10.5c0 4.01 3.44 7.37 8.09 8.25.31.07.74.21.85.48.1.25.06.63.03.88l-.14.82c-.04.25-.2.96.84.52s5.58-3.29 7.61-5.63C21.31 13.51 22 12.07 22 10.5 22 5.81 17.52 2 12 2z" fill="#fff"/></svg>
         <span id="t-line">LINEで使う</span>
       </a>
-      <a href="https://t.me/" class="ch-btn tg" target="_blank">
+      <a href="https://t.me/chatweb_ai_bot" class="ch-btn tg" target="_blank">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none"><path d="M12 0C5.37 0 0 5.37 0 12s5.37 12 12 12 12-5.37 12-12S18.63 0 12 0zm5.53 8.15l-1.88 8.85c-.14.63-.51.78-.84.49l-2.31-1.7-1.79 1.72c-.2.2-.36.36-.74.36l.27-3.78 6.88-6.22c.3-.27-.07-.42-.47-.16L8.09 13.29l-2.61-.82c-.57-.18-.58-.57.12-.84l11.03-4.27c.47-.17.88.11.73.79h.17z" fill="#fff"/></svg>
         <span id="t-tg">Telegramで使う</span>
       </a>
-    </div>
-
-    <!-- Simple info -->
-    <div class="info">
-      <div class="info-card">
-        <div class="ic">&#x26A1;</div>
-        <h3 id="t-i1">無料</h3>
-        <p id="t-i1d">登録不要ですぐに使える</p>
-      </div>
-      <div class="info-card">
-        <div class="ic">&#x1F916;</div>
-        <h3 id="t-i2">賢い</h3>
-        <p id="t-i2d">GPT-4o / Claude / Gemini</p>
-      </div>
-      <div class="info-card">
-        <div class="ic">&#x1F4AC;</div>
-        <h3 id="t-i3">どこでも</h3>
-        <p id="t-i3d">LINE・Telegram・Web</p>
-      </div>
     </div>
   </div>
 
   <footer>
     <a href="https://github.com/yukihamada/nanobot" target="_blank">GitHub</a> &middot;
     <a href="mailto:hello@chatweb.ai">Contact</a> &middot;
-    nanobot &copy; 2025-2026
+    chatweb.ai &copy; 2025-2026
   </footer>
 
   <script>
@@ -302,7 +282,7 @@
 
     input.addEventListener('keydown', e => { if (e.key === 'Enter' && !e.isComposing) send(); });
 
-    function sendSuggest(text) {
+    function sendRecipe(text) {
       input.value = text;
       send();
     }
@@ -311,8 +291,6 @@
       const text = input.value.trim();
       if (!text) return;
       input.value = '';
-      const sg = document.getElementById('suggests');
-      if (sg) sg.style.display = 'none';
       addMsg(text, 'user');
 
       const typing = document.createElement('div');
@@ -345,45 +323,126 @@
       msgs.scrollTop = msgs.scrollHeight;
     }
 
-    // i18n
-    const T = {
+    // Recipes data
+    const R = {
       ja: {
-        title: 'AIと話してみよう',
-        sub: 'OpenClawがやることを、Rust製で高速に。無料。',
-        welcome: 'こんにちは！タップして試してみてください。',
-        line: 'LINEで使う',
-        tg: 'Telegramで使う',
-        i1: '高速', i1d: 'Rust製 — 応答 <100ms',
-        i2: '賢い', i2d: 'Claude / GPT-4o / Gemini',
-        i3: 'どこでも', i3d: 'LINE・Telegram・Web',
-        suggests: [
-          '今日のAI最新ニュースを教えて',
-          'この文を英語にして: 明日の会議は10時からです',
-          'Pythonでフィボナッチ数列を書いて',
-          'ビジネスメールの下書きを作って',
-          '来週の献立を考えて',
-          'nanobotとOpenClawの違いは？',
+        categories: [
+          {
+            icon: '🔍', title: 'リサーチ・競合調査',
+            items: [
+              { name: '競合の価格監視', desc: 'Amazon・楽天で商品の最安値をチェック', prompt: 'Amazon、楽天、ヨドバシカメラで「iPhone 16 Pro」の価格を比較して。最安値のURLと価格を教えて。' },
+              { name: '見込み顧客リスト作成', desc: 'AIスタートアップの資金調達情報を収集', prompt: '先月資金調達を発表した日本のAIスタートアップをリストアップして。会社名、CEO名、事業内容をまとめて。' },
+              { name: 'SEO順位チェック', desc: 'キーワードの検索順位を分析', prompt: '「AIエージェント」「SaaS構築」「Rust AWS」でGoogle検索の上位10サイトをリストして。SEO改善のアドバイスもお願い。' },
+            ]
+          },
+          {
+            icon: '⚡', title: '業務自動化',
+            items: [
+              { name: '請求書処理の自動化', desc: 'PDFの請求書を読み取って管理', prompt: '請求書の処理を自動化する方法を教えて。メール受信→OCR→データベース登録→承認依頼の流れを具体的に設計して。' },
+              { name: '会議の事前準備', desc: '相手企業の情報を自動収集', prompt: '明日「株式会社サンプル」と会議があります。この会社の最新ニュース、事業概要、競合他社をまとめた事前準備レポートを作って。' },
+              { name: '問い合わせ自動分類', desc: 'クレームと営業メールを振り分け', prompt: '顧客からの問い合わせを自動で分類するシステムを設計して。「クレーム」「質問」「営業メール」「パートナーシップ提案」に分けて、それぞれの対応テンプレートも作って。' },
+            ]
+          },
+          {
+            icon: '🛠️', title: '開発・DevOps',
+            items: [
+              { name: 'コードレビュー自動化', desc: 'PRのコード品質を自動チェック', prompt: 'Rustのコードレビューチェックリストを作って。パフォーマンス、安全性、可読性の観点で。clippyのよくある警告と修正方法も含めて。' },
+              { name: '障害対応手順書', desc: 'エラー分析と自動復旧の設計', prompt: 'AWSでLambdaのエラー率が急上昇した時の障害対応手順書を作って。CloudWatchアラーム→ログ分析→原因特定→復旧→報告の流れで。' },
+              { name: 'API仕様書の自動生成', desc: 'コードからOpenAPIドキュメント作成', prompt: 'REST APIの設計をして。ユーザー管理（CRUD）、認証（JWT）、ファイルアップロードのエンドポイントをOpenAPI 3.0形式で書いて。' },
+            ]
+          },
+          {
+            icon: '🌍', title: 'プライベート・ライフスタイル',
+            items: [
+              { name: '格安チケットハンター', desc: '航空券の最安値を探す', prompt: '来月の週末で、東京発-沖縄行きの往復航空券をできるだけ安く取る方法を教えて。LCCも含めて比較して。' },
+              { name: '物件パトロール', desc: '条件に合う新着物件を検索', prompt: '世田谷区で2LDK、15万円以下、駅徒歩10分以内の賃貸物件を探すのに最適な方法を教えて。チェックすべきポイントも。' },
+              { name: '献立プランナー', desc: '1週間分の献立を自動作成', prompt: '来週の夕食の献立を月曜から金曜まで考えて。予算は1食500円以内、30分で作れるもの。買い物リストもまとめて。' },
+            ]
+          },
         ],
       },
       en: {
-        title: 'Chat with AI',
-        sub: 'What OpenClaw does, but faster in Rust. Free.',
-        welcome: 'Hi! Tap a suggestion or type anything.',
-        line: 'Use on LINE',
-        tg: 'Use on Telegram',
-        i1: 'Fast', i1d: 'Rust-powered — <100ms',
-        i2: 'Smart', i2d: 'Claude / GPT-4o / Gemini',
-        i3: 'Anywhere', i3d: 'LINE, Telegram, Web',
-        suggests: [
-          'Summarize today\'s AI news',
-          'Translate to Japanese: The meeting is at 10am',
-          'Write a Python fibonacci function',
-          'Draft a business email',
-          'Plan meals for next week',
-          'How is nanobot different from OpenClaw?',
+        categories: [
+          {
+            icon: '🔍', title: 'Research & Analysis',
+            items: [
+              { name: 'Competitor Price Watch', desc: 'Compare prices across major retailers', prompt: 'Compare prices for "iPhone 16 Pro" across Amazon, Best Buy, and Walmart. Show me the best deals with links.' },
+              { name: 'Lead Generation', desc: 'Find AI startups that raised funding', prompt: 'List AI startups that announced funding rounds last month. Include company name, CEO, and funding amount.' },
+              { name: 'SEO Rank Check', desc: 'Analyze search rankings for keywords', prompt: 'Analyze the top 10 Google results for "AI agent", "SaaS builder", "Rust AWS". Give SEO improvement advice.' },
+            ]
+          },
+          {
+            icon: '⚡', title: 'Business Automation',
+            items: [
+              { name: 'Invoice Processing', desc: 'Automate invoice reading and filing', prompt: 'Design an automated invoice processing workflow: email receipt → OCR → database entry → approval request. Be specific.' },
+              { name: 'Meeting Prep', desc: 'Auto-gather info about meeting partners', prompt: 'I have a meeting with "Sample Corp" tomorrow. Create a prep report with their latest news, business overview, and competitors.' },
+              { name: 'Inquiry Auto-Sort', desc: 'Classify customer inquiries automatically', prompt: 'Design a system to auto-classify customer inquiries into: complaint, question, sales email, partnership. Include response templates for each.' },
+            ]
+          },
+          {
+            icon: '🛠️', title: 'Dev & DevOps',
+            items: [
+              { name: 'Code Review Automation', desc: 'Auto-check PR code quality', prompt: 'Create a Rust code review checklist covering performance, safety, and readability. Include common clippy warnings and fixes.' },
+              { name: 'Incident Response', desc: 'Error analysis and auto-recovery', prompt: 'Create an incident response playbook for AWS Lambda error rate spikes. Cover: CloudWatch alarm → log analysis → root cause → recovery → report.' },
+              { name: 'API Spec Generator', desc: 'Generate OpenAPI docs from requirements', prompt: 'Design a REST API with user management (CRUD), auth (JWT), and file upload endpoints in OpenAPI 3.0 format.' },
+            ]
+          },
+          {
+            icon: '🌍', title: 'Personal & Lifestyle',
+            items: [
+              { name: 'Cheap Flight Hunter', desc: 'Find the best flight deals', prompt: 'Find the cheapest round-trip flights from Tokyo to Okinawa next month on weekends. Include budget airlines.' },
+              { name: 'Apartment Finder', desc: 'Search for rentals matching your criteria', prompt: 'What should I look for when searching for a 2BR apartment under $1500/month near downtown? Give me a checklist.' },
+              { name: 'Meal Planner', desc: 'Create a weekly dinner plan', prompt: 'Plan weekday dinners for next week. Budget: $10/meal, under 30 minutes to cook. Include a shopping list.' },
+            ]
+          },
         ],
       }
     };
+
+    // i18n
+    const T = {
+      ja: {
+        title: 'AIに何でも頼んでみよう',
+        sub: '24時間稼働のAIアシスタント。リサーチ・自動化・開発まで。',
+        welcome: 'こんにちは！何でもお任せください。下のカードから選ぶか、自由に入力してください。',
+        line: 'LINEで使う',
+        tg: 'Telegramで使う',
+        ph: '何でも聞いてください...',
+        send: '送信',
+      },
+      en: {
+        title: 'Ask AI to do anything',
+        sub: '24/7 AI assistant. Research, automation, and development.',
+        welcome: 'Hi! Pick a task below or type anything you need.',
+        line: 'Use on LINE',
+        tg: 'Use on Telegram',
+        ph: 'Ask me anything...',
+        send: 'Send',
+      }
+    };
+
+    function renderRecipes(l) {
+      const section = document.getElementById('recipe-section');
+      section.innerHTML = '';
+      const cats = R[l].categories;
+      cats.forEach(cat => {
+        const h = document.createElement('div');
+        h.className = 'recipes';
+        h.innerHTML = '<h2>' + cat.icon + ' ' + cat.title + '</h2>';
+        const grid = document.createElement('div');
+        grid.className = 'recipe-grid';
+        cat.items.forEach(item => {
+          const card = document.createElement('div');
+          card.className = 'recipe-card';
+          card.innerHTML = '<h4>' + item.name + '</h4><p>' + item.desc + '</p>';
+          card.onclick = () => sendRecipe(item.prompt);
+          grid.appendChild(card);
+        });
+        h.appendChild(grid);
+        section.appendChild(h);
+      });
+    }
+
     function setLang(l) {
       document.documentElement.lang = l;
       localStorage.setItem('nl', l);
@@ -395,25 +454,9 @@
       document.getElementById('t-welcome').textContent = t.welcome;
       document.getElementById('t-line').textContent = t.line;
       document.getElementById('t-tg').textContent = t.tg;
-      document.getElementById('t-i1').textContent = t.i1;
-      document.getElementById('t-i1d').textContent = t.i1d;
-      document.getElementById('t-i2').textContent = t.i2;
-      document.getElementById('t-i2d').textContent = t.i2d;
-      document.getElementById('t-i3').textContent = t.i3;
-      document.getElementById('t-i3d').textContent = t.i3d;
-      input.placeholder = l === 'ja' ? 'メッセージを入力...' : 'Type a message...';
-      document.getElementById('send-btn').textContent = l === 'ja' ? '送信' : 'Send';
-      // Render suggest buttons
-      const sg = document.getElementById('suggests');
-      sg.innerHTML = '';
-      sg.style.display = 'flex';
-      (t.suggests || []).forEach(s => {
-        const b = document.createElement('button');
-        b.className = 'suggest-btn';
-        b.textContent = s;
-        b.onclick = () => sendSuggest(s);
-        sg.appendChild(b);
-      });
+      input.placeholder = t.ph;
+      document.getElementById('send-btn').textContent = t.send;
+      renderRecipes(l);
     }
     setLang(localStorage.getItem('nl') || (navigator.language.startsWith('ja') ? 'ja' : 'en'));
   </script>


### PR DESCRIPTION
## Summary
- **ブランド変更**: ロゴ・タイトル・フッターを `chatweb.ai` に統一
- **レシピカード**: 4カテゴリ×3 = 12のタスクテンプレート
  - リサーチ・競合調査（価格監視、リード生成、SEO）
  - 業務自動化（請求書処理、会議準備、問い合わせ分類）
  - 開発・DevOps（コードレビュー、障害対応、API仕様書）
  - ライフスタイル（格安航空券、物件探し、献立作成）
- **Bot URL設定**: LINE (@619jcqqh), Telegram (@chatweb_ai_bot)
- **Telegram Webhook**: `api.chatweb.ai/webhooks/telegram` に設定済み

## Test plan
- [x] chatweb.ai でロゴ確認
- [x] 12枚のレシピカード表示確認
- [x] カードクリック → AI返信動作確認（献立プランナーでテスト）
- [x] LINE/Telegram ボタンの遷移先URL確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)