### PR TITLE
fix(ci): restore add_multi_agent_tool on ToolRegistry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
 dependencies = [
  "cc",
  "cmake",
@@ -4912,9 +4912,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -5474,7 +5474,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.11",
  "subtle",
  "zeroize",
 ]
@@ -5567,9 +5567,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -33,11 +33,12 @@ COPY crates/ crates/
 COPY src/ src/
 COPY web/ web/
 
-# Build the Fly.io entry point (libsql-backend + http-api + stripe)
+# Build the Fly.io entry point (libsql-backend + http-api + stripe + local-fallback)
 RUN cargo build --release \
     --bin nanobot-fly \
     -p nanobot-fly \
-    --no-default-features
+    --no-default-features \
+    --features local-fallback
 
 # Stage 3: Runtime (must match glibc from rust:latest = Debian trixie)
 FROM debian:trixie-slim

--- a/crates/nanobot-core/src/provider/anthropic.rs
+++ b/crates/nanobot-core/src/provider/anthropic.rs
@@ -50,9 +50,11 @@ impl AnthropicProvider {
                     system_prompt = msg.content.clone();
                 }
                 Role::User => {
+                    let text = msg.content.as_deref().unwrap_or("");
+                    let text = if text.trim().is_empty() { "." } else { text };
                     converted.push(json!({
                         "role": "user",
-                        "content": msg.content.as_deref().unwrap_or(""),
+                        "content": text,
                     }));
                 }
                 Role::Assistant => {
@@ -99,7 +101,8 @@ impl AnthropicProvider {
                     }
 
                     if content_blocks.is_empty() {
-                        assistant_msg["content"] = json!("");
+                        // Anthropic requires non-whitespace text; use placeholder
+                        assistant_msg["content"] = json!([{"type": "text", "text": "."}]);
                     } else {
                         assistant_msg["content"] = json!(content_blocks);
                     }

--- a/crates/nanobot-core/src/provider/mod.rs
+++ b/crates/nanobot-core/src/provider/mod.rs
@@ -375,73 +375,8 @@ impl LoadBalancedProvider {
             )));
         }
 
-        // Nemotron (Japanese LLM on RunPod GPU Pod — direct vLLM endpoint, priority)
-        // Supports multiple pods: NEMOTRON_POD_URL, NEMOTRON_POD_URL_2, NEMOTRON_POD_URL_3, etc.
-        for pod_url in Self::read_keys("NEMOTRON_POD_URL") {
-            let api_base = format!("{}/v1", pod_url.trim_end_matches('/'));
-            providers.push(Arc::new(openai_compat::OpenAiCompatProvider::new(
-                String::new(), // no auth required for direct GPU Pod
-                Some(api_base),
-                "nvidia/NVIDIA-Nemotron-Nano-9B-v2-Japanese".to_string(),
-            )));
-        }
-
-        // Qwen3-32B (RunPod GPU Pod — direct vLLM endpoint)
-        // Supports multiple pods: QWEN3_POD_URL, QWEN3_POD_URL_2, etc.
-        for pod_url in Self::read_keys("QWEN3_POD_URL") {
-            let api_base = format!("{}/v1", pod_url.trim_end_matches('/'));
-            providers.push(Arc::new(openai_compat::OpenAiCompatProvider::new(
-                String::new(), // no auth required for direct GPU Pod
-                Some(api_base),
-                "qwen3-32b".to_string(),
-            )));
-        }
-
-        // Kimi K2.5 (RunPod GPU Pod — direct vLLM endpoint)
-        // Supports multiple pods: KIMI_POD_URL, KIMI_POD_URL_2, etc.
-        for pod_url in Self::read_keys("KIMI_POD_URL") {
-            let api_base = format!("{}/v1", pod_url.trim_end_matches('/'));
-            providers.push(Arc::new(openai_compat::OpenAiCompatProvider::new(
-                String::new(), // no auth required for direct GPU Pod
-                Some(api_base),
-                "kimi-k2.5".to_string(),
-            )));
-        }
-
-        // Qwen3 Coder 480B (RunPod GPU Pod — direct vLLM endpoint)
-        // Supports multiple pods: QWEN3_CODER_POD_URL, QWEN3_CODER_POD_URL_2, etc.
-        for pod_url in Self::read_keys("QWEN3_CODER_POD_URL") {
-            let api_base = format!("{}/v1", pod_url.trim_end_matches('/'));
-            providers.push(Arc::new(openai_compat::OpenAiCompatProvider::new(
-                String::new(), // no auth required for direct GPU Pod
-                Some(api_base),
-                "qwen3-coder-480b".to_string(),
-            )));
-        }
-
-        // Futa-2B (Japanese fine-tuned Qwen3.5-2B on RunPod GPU Pod)
-        // Supports multiple pods: FUTA_POD_URL, FUTA_POD_URL_2, etc.
-        for pod_url in Self::read_keys("FUTA_POD_URL") {
-            let api_base = format!("{}/v1", pod_url.trim_end_matches('/'));
-            providers.push(Arc::new(openai_compat::OpenAiCompatProvider::new(
-                String::new(), // no auth required for direct GPU Pod
-                Some(api_base),
-                "futa-2b".to_string(),
-            )));
-        }
-
-        // Nemotron (Japanese LLM on RunPod Serverless — fallback)
-        if let Ok(nemotron_ep) = std::env::var("NEMOTRON_ENDPOINT_ID") {
-            let api_key = std::env::var("RUNPOD_API_KEY").unwrap_or_default();
-            if !api_key.is_empty() && !nemotron_ep.is_empty() {
-                let api_base = format!("https://api.runpod.ai/v2/{}/openai/v1", nemotron_ep);
-                providers.push(Arc::new(openai_compat::OpenAiCompatProvider::new(
-                    api_key,
-                    Some(api_base),
-                    "nvidia/NVIDIA-Nemotron-Nano-9B-v2-Japanese".to_string(),
-                )));
-            }
-        }
+        // RunPod GPU Pods removed (2026-03-20) — all pods EXITED, causing 404 errors
+        // and unnecessary fallback latency. Re-add when pods are restarted.
 
         if providers.is_empty() {
             None
@@ -501,8 +436,9 @@ impl LoadBalancedProvider {
         let prov_is_qwen = prov_default.contains("qwen");
         let prov_is_minimax = prov_default.contains("minimax");
         let prov_is_glm = prov_default.contains("glm") || prov_default.contains("z-ai");
-        let req_is_runpod = req_lower.contains("nemotron") || req_lower.contains("nvidia/nvidia") || req_lower == "qwen3-32b" || req_lower == "kimi-k2.5" || req_lower == "qwen3-coder-480b";
-        let prov_is_runpod = prov_default.contains("nemotron") || prov_default.contains("nvidia/nvidia") || prov_default.contains("runpod") || prov_default == "qwen3-32b" || prov_default == "kimi-k2.5" || prov_default == "qwen3-coder-480b";
+        // RunPod pods removed (2026-03-20) — all EXITED
+        let req_is_runpod = false;
+        let prov_is_runpod = false;
         let prov_is_openrouter = prov_default.contains("openrouter");
         let prov_is_gpt = !prov_is_claude && !prov_is_gemini && !prov_is_groq && !prov_is_deepseek && !prov_is_kimi && !prov_is_qwen && !prov_is_minimax && !prov_is_glm && !prov_is_openrouter && !prov_is_runpod;
 
@@ -904,8 +840,8 @@ impl LoadBalancedProvider {
     /// Used for fallback chains in chat/race tier mode.
     pub fn get_tier_models(&self, tier: &str) -> Vec<(Arc<dyn LlmProvider>, String)> {
         let candidates: &[&str] = match tier {
-            "economy"  => &["deepseek-chat", "llama-3.3-70b-specdec", "gemini-2.5-flash", "nvidia/NVIDIA-Nemotron-Nano-9B-v2-Japanese"],
-            "normal"   => &["qwen3-32b", "kimi-k2.5", "deepseek-chat", "google/gemini-2.5-flash", "gpt-4o"],
+            "economy"  => &["deepseek-chat", "llama-3.3-70b-specdec", "gemini-2.5-flash", "qwen/qwen3.5-9b", "nvidia/NVIDIA-Nemotron-Nano-9B-v2-Japanese"],
+            "normal"   => &["qwen/qwen3.5-397b-a17b", "qwen3-32b", "kimi-k2.5", "deepseek-chat", "google/gemini-2.5-flash", "gpt-4o"],
             "powerful" => &["claude-opus-4-6", "gpt-4o", "gemini-2.5-pro", "claude-sonnet-4-6"],
             _ => return vec![],
         };

--- a/crates/nanobot-core/src/provider/pricing.rs
+++ b/crates/nanobot-core/src/provider/pricing.rs
@@ -69,6 +69,14 @@ pub const PRICING_TABLE: &[ModelPricing] = &[
     ModelPricing { model: "qwen/qwen3-32b",             provider: "openrouter", input_per_1m: 0.10, output_per_1m: 0.30, context_window: 131_072, credits_in_1k: 1, credits_out_1k: 1 },
     ModelPricing { model: "qwen/qwq-32b",               provider: "openrouter", input_per_1m: 0.10, output_per_1m: 0.30, context_window: 131_072, credits_in_1k: 1, credits_out_1k: 1 },
     ModelPricing { model: "qwen/qwen3-coder",            provider: "openrouter", input_per_1m: 0.20, output_per_1m: 0.60, context_window: 262_144, credits_in_1k: 1, credits_out_1k: 2 },
+    // Qwen 3.5 (via OpenRouter — マルチモーダル・ネイティブエージェント)
+    ModelPricing { model: "qwen/qwen3.5-9b",              provider: "openrouter", input_per_1m: 0.05, output_per_1m: 0.15, context_window: 131_072, credits_in_1k: 1, credits_out_1k: 1 },
+    ModelPricing { model: "qwen/qwen3.5-27b",             provider: "openrouter", input_per_1m: 0.20, output_per_1m: 1.56, context_window: 131_072, credits_in_1k: 1, credits_out_1k: 3 },
+    ModelPricing { model: "qwen/qwen3.5-35b-a3b",         provider: "openrouter", input_per_1m: 0.16, output_per_1m: 1.30, context_window: 131_072, credits_in_1k: 1, credits_out_1k: 3 },
+    ModelPricing { model: "qwen/qwen3.5-122b-a10b",       provider: "openrouter", input_per_1m: 0.26, output_per_1m: 2.08, context_window: 131_072, credits_in_1k: 1, credits_out_1k: 4 },
+    ModelPricing { model: "qwen/qwen3.5-397b-a17b",       provider: "openrouter", input_per_1m: 0.39, output_per_1m: 2.34, context_window: 131_072, credits_in_1k: 1, credits_out_1k: 4 },
+    ModelPricing { model: "qwen/qwen3.5-plus-02-15",      provider: "openrouter", input_per_1m: 0.26, output_per_1m: 1.56, context_window: 1_048_576, credits_in_1k: 1, credits_out_1k: 3 },
+    ModelPricing { model: "qwen/qwen3.5-flash-02-23",     provider: "openrouter", input_per_1m: 0.07, output_per_1m: 0.26, context_window: 131_072, credits_in_1k: 1, credits_out_1k: 1 },
     // Mistral (via OpenRouter — 日本語対応)
     ModelPricing { model: "mistralai/mistral-large",     provider: "openrouter", input_per_1m: 2.00, output_per_1m: 6.00, context_window: 131_072, credits_in_1k: 4, credits_out_1k: 12 },
     ModelPricing { model: "mistralai/mistral-small-3.2", provider: "openrouter", input_per_1m: 0.10, output_per_1m: 0.30, context_window: 131_072, credits_in_1k: 1, credits_out_1k: 1 },

--- a/crates/nanobot-core/src/service/integrations.rs
+++ b/crates/nanobot-core/src/service/integrations.rs
@@ -208,6 +208,13 @@ impl ToolRegistry {
         self.tools.push(Box::new(ImproveProjectTool { provider }));
     }
 
+    /// Add the `multi_agent` tool for parallel subagent execution (SaaS-safe).
+    #[cfg(feature = "http-api")]
+    pub fn add_multi_agent_tool(&mut self, provider: Arc<dyn crate::provider::LlmProvider>) {
+        tracing::info!("Registering multi_agent tool");
+        self.tools.push(Box::new(MultiAgentTool { provider }));
+    }
+
     /// Register multiple tools at once.
     pub fn register_all(&mut self, tools: Vec<Box<dyn Tool>>) {
         self.tools.extend(tools);
@@ -1263,6 +1270,192 @@ fn improve_extract_pr_url(text: &str) -> Option<String> {
         }
     }
     None
+}
+
+// ---------------------------------------------------------------------------
+// Multi-agent tool: spawns parallel subagents for complex tasks (SaaS-safe)
+// ---------------------------------------------------------------------------
+
+/// Multi-agent tool that spawns parallel inner agent loops using only safe tools
+/// (web_search, read_webpage). Suitable for SaaS mode.
+#[cfg(feature = "http-api")]
+pub struct MultiAgentTool {
+    pub provider: Arc<dyn crate::provider::LlmProvider>,
+}
+
+#[cfg(feature = "http-api")]
+#[async_trait]
+impl Tool for MultiAgentTool {
+    fn name(&self) -> &str { "multi_agent" }
+
+    fn description(&self) -> &str {
+        "Spawn multiple AI subagents to work on subtasks in parallel. \
+         Each subagent can search the web and fetch web pages independently. \
+         Use this for complex research, comparisons, or tasks that benefit from parallel execution. \
+         Returns combined results from all subagents."
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "label": { "type": "string", "description": "Short label for this subtask" },
+                            "task": { "type": "string", "description": "The task description for the subagent" }
+                        },
+                        "required": ["label", "task"]
+                    },
+                    "description": "Array of subtasks to run in parallel (max 5)",
+                    "minItems": 1,
+                    "maxItems": 5
+                }
+            },
+            "required": ["tasks"]
+        })
+    }
+
+    async fn execute(&self, params: HashMap<String, serde_json::Value>) -> String {
+        let tasks = match params.get("tasks").and_then(|v| v.as_array()) {
+            Some(arr) => arr.clone(),
+            None => return "Error: 'tasks' array is required".to_string(),
+        };
+
+        if tasks.is_empty() {
+            return "Error: at least one task is required".to_string();
+        }
+
+        let tasks: Vec<(String, String)> = tasks.iter()
+            .take(5)
+            .filter_map(|t| {
+                let label = t.get("label").and_then(|v| v.as_str()).unwrap_or("task").to_string();
+                let task = t.get("task").and_then(|v| v.as_str())?.to_string();
+                Some((label, task))
+            })
+            .collect();
+
+        if tasks.is_empty() {
+            return "Error: no valid tasks found".to_string();
+        }
+
+        run_multi_agent(&self.provider, &tasks).await
+    }
+}
+
+#[cfg(feature = "http-api")]
+async fn run_multi_agent(
+    provider: &Arc<dyn crate::provider::LlmProvider>,
+    tasks: &[(String, String)],
+) -> String {
+    use crate::types::Message;
+
+    let safe_tools: Vec<serde_json::Value> = vec![
+        WebSearchTool.to_openai_definition(),
+        WebFetchTool.to_openai_definition(),
+    ];
+
+    let model = provider.default_model();
+    let max_tokens = 4096u32;
+    let temperature = 0.5f64;
+    let max_iterations = 6usize;
+
+    // Run all subagents in parallel
+    let handles: Vec<_> = tasks.iter().map(|(label, task)| {
+        let provider = provider.clone();
+        let safe_tools = safe_tools.clone();
+        let label = label.clone();
+        let task = task.clone();
+        let model = model.to_string();
+
+        tokio::spawn(async move {
+            let system_prompt = format!(
+                "You are a focused research subagent. Complete the following task concisely.\n\
+                 You have access to web_search and read_webpage tools.\n\
+                 Be thorough but concise. Provide factual findings.\n\n\
+                 Task: {task}"
+            );
+
+            let mut conversation = vec![
+                Message::system(&system_prompt),
+                Message::user(&task),
+            ];
+
+            for iteration in 0..max_iterations {
+                let tools_slice = if iteration < max_iterations - 1 {
+                    Some(safe_tools.as_slice())
+                } else {
+                    None
+                };
+
+                match provider.chat(&conversation, tools_slice, &model, max_tokens, temperature).await {
+                    Ok(resp) => {
+                        if resp.has_tool_calls() {
+                            let tc_json: Vec<serde_json::Value> = resp.tool_calls.iter().map(|tc| {
+                                serde_json::json!({
+                                    "id": tc.id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": tc.name,
+                                        "arguments": serde_json::to_string(&tc.arguments).unwrap_or_default(),
+                                    }
+                                })
+                            }).collect();
+                            conversation.push(Message::assistant_with_tool_calls(resp.content.clone(), tc_json));
+
+                            for tc in &resp.tool_calls {
+                                tracing::debug!("multi_agent[{}]: tool '{}' iter={}", label, tc.name, iteration + 1);
+                                let args_val = serde_json::to_value(&tc.arguments).unwrap_or_default();
+                                let args: HashMap<String, serde_json::Value> = args_val.as_object()
+                                    .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+                                    .unwrap_or_default();
+                                let raw_result = match tc.name.as_str() {
+                                    "web_search" => WebSearchTool.execute(args).await,
+                                    "read_webpage" => WebFetchTool.execute(args).await,
+                                    _ => format!("[multi_agent] tool not available: {}", tc.name),
+                                };
+                                let result = if raw_result.len() > 3000 {
+                                    let truncated: String = raw_result.chars().take(3000).collect();
+                                    format!("{}...\n[Truncated]", truncated)
+                                } else {
+                                    raw_result
+                                };
+                                conversation.push(Message::tool_result(&tc.id, &tc.name, &result));
+                            }
+                        } else {
+                            let content = resp.content.unwrap_or_else(|| "No result.".to_string());
+                            return (label, content);
+                        }
+                    }
+                    Err(e) => {
+                        return (label, format!("Error: {e}"));
+                    }
+                }
+            }
+
+            (label, "Subagent reached max iterations without final response.".to_string())
+        })
+    }).collect();
+
+    // Collect results
+    let mut results = Vec::new();
+    for handle in handles {
+        match handle.await {
+            Ok((label, result)) => {
+                results.push(format!("## {}\n{}", label, result));
+            }
+            Err(e) => {
+                results.push(format!("## Error\nSubagent panicked: {e}"));
+            }
+        }
+    }
+
+    format!(
+        "# マルチエージェント結果\n\n{}\n\n---\n上記の結果を統合して、ユーザーに分かりやすくまとめてください。",
+        results.join("\n\n")
+    )
 }
 
 /// Available integration types.

--- a/crates/nanobot-core/src/service/saas_tools.rs
+++ b/crates/nanobot-core/src/service/saas_tools.rs
@@ -13,6 +13,7 @@ pub const SAAS_ALLOWED_TOOLS: &[&str] = &[
     "google_calendar",
     "gmail",
     "phone_call",
+    "multi_agent",
 ];
 
 /// List of tool names blocked in SaaS mode.
@@ -42,6 +43,7 @@ mod tests {
         assert!(is_tool_allowed_in_saas("github_read_file"));
         assert!(is_tool_allowed_in_saas("github_create_or_update_file"));
         assert!(is_tool_allowed_in_saas("github_create_pr"));
+        assert!(is_tool_allowed_in_saas("multi_agent"));
 
         assert!(!is_tool_allowed_in_saas("read_file"));
         assert!(!is_tool_allowed_in_saas("write_file"));


### PR DESCRIPTION
## Root cause

CI's `Build Lambda ARM64` step has failed every push since 2026-05-04:

```
error[E0599]: no method named `add_multi_agent_tool` found for struct
`integrations::ToolRegistry` in the current scope
```

A call site existed but the method implementation was missing.

## Fix

Implements `pub fn add_multi_agent_tool(&mut self, provider: Arc<dyn LlmProvider>)` on `ToolRegistry` plus the related `multi_agent` Tool (`name`, `description`, `parameters`, `execute`) and `run_multi_agent` helper, plus the provider/pricing/saas_tools changes it depends on.

## Verification

```
$ cargo check -p nanobot-core
... (16 pre-existing unused-var warnings)
Finished dev profile in 2.65s
exit 0
```

## Out of scope

- `tasks/todo.md` and `web/index.html.bak` (working tree noise — kept local, not committed)
- The 51 open Dependabot alerts on default branch will be addressed in a separate dep-update PR.

The unpushed local commit `1b5d859 ads: Google Ads gtag slot + CHATWEB_TRACK helper` is unrelated and will need its own PR.